### PR TITLE
Java version update

### DIFF
--- a/conf/distro/include/angstrom-java.inc
+++ b/conf/distro/include/angstrom-java.inc
@@ -3,7 +3,7 @@ PREFERRED_PROVIDER_virtual/java-initial = "cacao-initial"
 PREFERRED_PROVIDER_virtual/java-native = "jamvm-native"
 PREFERRED_PROVIDER_virtual/javac-native = "ecj-bootstrap-native"
 
-PREFERRED_VERSION_openjdk-6-jre = "6b27-1.12.5"
+PREFERRED_VERSION_openjdk-6-jre = "6b27-1.12.8"
 PREFERRED_VERSION_icedtea6-native = "1.8.11"
 
 PREFERRED_VERSION_openjdk-7-jre = "25b30-2.3.12"


### PR DESCRIPTION
Hi Koen,

building an Angstrom 2013.12 image including java fails for me, because the preferred version of openjdk-6-jre is not available in meta-java repository version checked out by setup-scripts. This commit updates the version in distro include. Please pull, if this is the right place to fix this.

Thank you
