### PR TITLE
overall: use oe.utils.* instead of deprecated base_*

### DIFF
--- a/conf/distro/angstrom.conf
+++ b/conf/distro/angstrom.conf
@@ -55,7 +55,7 @@ TOOLCHAIN_BRAND ?= ""
 # helpful for common users).
 # Also, it appears that no locales fit in 16Mb for now. "C" locale rules!
 ROOT_FLASH_SIZE ??= "32"
-IMAGE_LINGUAS ?= '${@base_less_or_equal("ROOT_FLASH_SIZE", "16", "", "en-us", d)}'
+IMAGE_LINGUAS ?= '${@oe.utils.less_or_equal("ROOT_FLASH_SIZE", "16", "", "en-us", d)}'
 
 # set feed path variables
 FEED_BASEPATH = "feeds/${DISTRO_VERSION}/${ANGSTROM_PKG_FORMAT}/${TCLIBC}/"
@@ -124,7 +124,7 @@ DISTRO_BLUETOOTH_MANAGER = "\
 
 # We want to ship extra debug utils in the rootfs when doing a debug build
 DEBUG_APPS ?= ""
-DEBUG_APPS += '${@base_conditional("DISTRO_TYPE", "release", "", "strace procps",d)}'
+DEBUG_APPS += '${@oe.utils.conditional("DISTRO_TYPE", "release", "", "strace procps",d)}'
 
 # This hooks into packagegroup-base, so it won't do anything if your images doesn't include packagegroup-base.
 # angstrom-version: ship this to have an identifiable rootfs so user can report bugs against a specific version

--- a/conf/distro/iota.conf
+++ b/conf/distro/iota.conf
@@ -77,7 +77,7 @@ TOOLCHAIN_BRAND ?= ""
 # helpful for common users).
 # Also, it appears that no locales fit in 16Mb for now. "C" locale rules!
 ROOT_FLASH_SIZE ??= "32"
-IMAGE_LINGUAS ?= '${@base_less_or_equal("ROOT_FLASH_SIZE", "16", "", "en-us", d)}'
+IMAGE_LINGUAS ?= '${@oe.utils.less_or_equal("ROOT_FLASH_SIZE", "16", "", "en-us", d)}'
 
 # set feed path variables
 FEED_BASEPATH = "feeds/${DISTRO_VERSION}/${ANGSTROM_PKG_FORMAT}/${TCLIBC}/"
@@ -146,7 +146,7 @@ DISTRO_BLUETOOTH_MANAGER = "\
 
 # We want to ship extra debug utils in the rootfs when doing a debug build
 DEBUG_APPS ?= ""
-DEBUG_APPS += '${@base_conditional("DISTRO_TYPE", "release", "", "strace procps",d)}'
+DEBUG_APPS += '${@oe.utils.conditional("DISTRO_TYPE", "release", "", "strace procps",d)}'
 
 # This hooks into packagegroup-base, so it won't do anything if your images doesn't include packagegroup-base.
 # angstrom-version: ship this to have an identifiable rootfs so user can report bugs against a specific version

--- a/recipes-images/angstrom/angstrom-image.bb
+++ b/recipes-images/angstrom/angstrom-image.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 IMAGE_PREPROCESS_COMMAND = "rootfs_update_timestamp ;"
 
 DISTRO_UPDATE_ALTERNATIVES ??= ""
-ROOTFS_PKGMANAGE_PKGS ?= '${@base_conditional("ONLINE_PACKAGE_MANAGEMENT", "none", "", "${ROOTFS_PKGMANAGE} ${DISTRO_UPDATE_ALTERNATIVES}", d)}'
+ROOTFS_PKGMANAGE_PKGS ?= '${@oe.utils.conditional("ONLINE_PACKAGE_MANAGEMENT", "none", "", "${ROOTFS_PKGMANAGE} ${DISTRO_UPDATE_ALTERNATIVES}", d)}'
 
 IMAGE_FEATURES += "empty-root-password allow-empty-password"
 


### PR DESCRIPTION
The compatibility functions have been removed with this commit:
http://cgit.openembedded.org/openembedded-core/commit/meta/classes/utils.bbclass?id=0391fcad9103abca0796a068f957d0df63ab4776

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>