### PR TITLE
systemd bbappend: remove unneeded glib-2.0 DEPENDS

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,7 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-DEPENDS += "glib-2.0"
-
 SRC_URI += "file://journald.conf"
 
 PACKAGECONFIG_append   = " \


### PR DESCRIPTION
This fixes dependency loops when enabling ptest feature.

Signed-off-by: Steffen Sledz <sledz@dresearch-fe.de>