### PR TITLE
base-files: allow users to access profile.d

### DIFF
--- a/recipes-core/base-files/base-files_3.0.14.bbappend
+++ b/recipes-core/base-files/base-files_3.0.14.bbappend
@@ -16,7 +16,7 @@ dirs755 += "${localstatedir}/cache \
 # Python fails to decode UTF8 is LANG is set to C
 # And we have UTF in /etc/os-release...
 do_install_append() {
-     install -m 0644 -d ${D}${sysconfdir}/profile.d
+     install -m 0755 -d ${D}${sysconfdir}/profile.d
      echo 'export LANG="en_US.UTF-8"' > ${D}${sysconfdir}/profile.d/utf8.sh 
 }
 


### PR DESCRIPTION
Change profile.d folder permissions to 755 so that non-root users can access
the folder. With 644 permissions non-root users get the errors like:
-sh: /etc/profile.d/utf8.sh: Permission denied

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>