### PR TITLE
layer.conf: add LAYERSERIES_COMPAT_angstrom-layer

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,3 +11,5 @@ BBFILE_PRIORITY_angstrom-layer = "7"
 SIGGEN_EXCLUDERECIPES_ABISAFE += " \
 	angstrom-feed-configs \
         "
+
+LAYERSERIES_COMPAT_angstrom-layer = "thud"


### PR DESCRIPTION
Avoid WARNING: Layer angstrom-layer should set LAYERSERIES_COMPAT_angstrom-layer in its conf/layer.conf file to list the core layer names it is compatible with.

Fix for issue #29 in thud branch.