### PR TITLE
gstreamer-0.10: Remove unsupported recipe bbappend

### DIFF
--- a/recipes-tweaks/gstreamer/gst-plugins-bad_0.10.23.bbappend
+++ b/recipes-tweaks/gstreamer/gst-plugins-bad_0.10.23.bbappend
@@ -1,3 +1,0 @@
-DEPENDS += "orc orc-native"
-EXTRA_OECONF =  "--disable-directfb --disable-examples --disable-vdpau --disable-apexsink --enable-experimental --enable-orc"
-

--- a/recipes-tweaks/gstreamer/gst-plugins-base_0.10.36.bbappend
+++ b/recipes-tweaks/gstreamer/gst-plugins-base_0.10.36.bbappend
@@ -1,2 +1,0 @@
-DEPENDS += "orc orc-native"
-EXTRA_OECONF += "--enable-orc"

--- a/recipes-tweaks/gstreamer/gst-plugins-good_0.10.31.bbappend
+++ b/recipes-tweaks/gstreamer/gst-plugins-good_0.10.31.bbappend
@@ -1,2 +1,0 @@
-DEPENDS += "orc orc-native"
-EXTRA_OECONF += "--enable-orc"

--- a/recipes-tweaks/gstreamer/gst-plugins-ugly_0.10.19.bbappend
+++ b/recipes-tweaks/gstreamer/gst-plugins-ugly_0.10.19.bbappend
@@ -1,2 +1,0 @@
-DEPENDS += "orc orc-native"
-EXTRA_OECONF += "--enable-orc"


### PR DESCRIPTION
gstreamer 0.10 is no longer included in yocto warrior branch.

Signed-off-by: Mario Schuknecht <mario.schuknecht@dresearch-fe.de>