### PR TITLE
packagegroup-gnome-gstreamer: fix DEPENDS

### DIFF
--- a/recipes-angstrom/packagegroups/packagegroup-gnome-gstreamer.bb
+++ b/recipes-angstrom/packagegroups/packagegroup-gnome-gstreamer.bb
@@ -9,7 +9,7 @@ inherit packagegroup
 # for backwards compatibility
 RPROVIDES_${PN} += "packagegroup-gnome3-gstreamer"
 
-DEPENDS_${PN} = " \
+DEPENDS = " \
   gst-plugins-base \
   gst-plugins-good \
   gst-plugins-bad \


### PR DESCRIPTION
Remove ${PN} from DEPENDS to avoid QA issue:
QA Issue: recipe uses DEPENDS_${PN}, should use DEPENDS [pkgvarcheck]
Fatal QA errors found, failing task.

Signed-off-by: Mario Schuknecht <mario.schuknecht@dresearch-fe.de>