### PR TITLE
Fix kernel version missing from startup banner

### DIFF
--- a/recipes-core/base-files/base-files_3.0.14.bbappend
+++ b/recipes-core/base-files/base-files_3.0.14.bbappend
@@ -33,7 +33,7 @@ do_install_angstromissue () {
             echo -n "${DISTRO_VERSION} " >> ${D}${sysconfdir}/issue
             echo -e "${DISTRO_VERSION} \n" >> ${D}${sysconfdir}/issue.net
         fi
-        echo "- Kernel \r" >> ${D}${sysconfdir}/issue
+        echo '- Kernel \\r' >> ${D}${sysconfdir}/issue
         echo >> ${D}${sysconfdir}/issue
     fi
 }


### PR DESCRIPTION
## Description

This PR properly escapes the `\r` sign used by /etc/issue to print the kernel version. Currently, the `\r` is interpreted as a carriage return and ignored. This leads to the following banner on startup:

```
.---O---.                                           
|       |                  .-.           o o        
|   |   |-----.-----.-----.| |   .----..-----.-----.
|       |     | __  |  ---'| '--.|  .-'|     |     |
|   |   |  |  |     |---  ||  --'|  |  |  '  | | | |
'---'---'--'--'--.  |-----''----''--'  '-----'-'-'-'
                -'  |
                '---'

The Angstrom Distribution angstrom ttyO0

Angstrom 2019.12 - Kernel 
```

After applying the patch, we're greeted by this banner:

```
.---O---.                                           
|       |                  .-.           o o        
|   |   |-----.-----.-----.| |   .----..-----.-----.
|       |     | __  |  ---'| '--.|  .-'|     |     |
|   |   |  |  |     |---  ||  --'|  |  |  '  | | | |
'---'---'--'--'--.  |-----''----''--'  '-----'-'-'-'
                -'  |
                '---'

The Angstrom Distribution angstrom ttyO0

Angstrom 2019.12 - Kernel 5.3.13-jumpnow
```