### PR TITLE
systemd-qt5-image: Fix 'is deprecated' warning

### DIFF
--- a/recipes-images/angstrom/systemd-qt5-image.bb
+++ b/recipes-images/angstrom/systemd-qt5-image.bb
@@ -1,6 +1,6 @@
 require systemd-image.bb
 
-inherit distro_features_check
+inherit features_check
 
 inherit populate_sdk_qt5
 


### PR DESCRIPTION
Use 'features_check' instead of 'distro_features_check' to avoid
warning.

Signed-off-by: Mario Schuknecht <mario.schuknecht@dresearch-fe.de>